### PR TITLE
Compression streams

### DIFF
--- a/src/lib/utils/compression.cpp
+++ b/src/lib/utils/compression.cpp
@@ -13,8 +13,9 @@
 // Decompress raw memory from the in_data vector into the out_data vector.
 // Function allocates memory for the output vector. Function takes the length of
 // the data after decompression.
-int Compression::inflate(std::vector<uint8_t> &in_data, std::vector<uint8_t> &out_data,
-            size_t decompressed_len) {
+int Compression::inflate(std::vector<uint8_t> &in_data,
+                         std::vector<uint8_t> &out_data,
+                         size_t decompressed_len) {
     int ret;
     z_stream strm;
     out_data.resize(decompressed_len);
@@ -63,6 +64,7 @@ int Compression::inflate(std::vector<uint8_t> &in_data, std::vector<uint8_t> &ou
 
             ret = inflate(&strm, Z_NO_FLUSH);
             assert(ret != Z_STREAM_ERROR);
+
             switch (ret) {
                 case Z_NEED_DICT:
                     ret = Z_DATA_ERROR;
@@ -83,4 +85,229 @@ int Compression::inflate(std::vector<uint8_t> &in_data, std::vector<uint8_t> &ou
     // Clean up and return.
     (void)inflateEnd(&strm);
     return ret == Z_STREAM_END ? Z_OK : Z_DATA_ERROR;
+}
+
+// Initialize buffer.
+Compression::DeflateStreambuf::DeflateStreambuf(size_t _buffer_size)
+    : buffer_size(_buffer_size) {
+    // Allocate new buffer.
+    buffer = new char[buffer_size];
+    // Set streambuf's internal pointer to buffer.
+    setp(buffer, buffer + buffer_size);
+}
+
+// Destructor flushes the buffer, deletes the allocated memory, closes the
+// output file, and frees the allocated Zlib state.
+Compression::DeflateStreambuf::~DeflateStreambuf() {
+    // Flush current buffer.
+    sync();
+
+    // Perform last write for Zlib to flush it's internal buffer.
+    strm.next_in = nullptr;
+    strm.avail_in = 0;
+    write_buffer(Z_FINISH);
+
+    delete[] buffer;
+    if (out_file) {
+        fclose(out_file);
+    }
+    (void)deflateEnd(&strm);
+}
+
+// Open file, allocate buffer, and initialize Zlib state.
+int Compression::DeflateStreambuf::open(std::string const &filename) {
+    // Open file.
+    out_file = fopen(filename.c_str(), "wb");
+    if (out_file == NULL) {
+        return ERROR;
+    }
+
+    // Initialize zlib stream.
+    strm.zalloc = Z_NULL;
+    strm.zfree = Z_NULL;
+    strm.opaque = Z_NULL;
+    int ret = deflateInit(&strm, Z_DEFAULT_COMPRESSION);
+    if (ret != Z_OK) {
+        return ERROR;
+    }
+    return OK;
+}
+
+// This function writes a character when the buffer is full.
+int Compression::DeflateStreambuf::overflow(int c) {
+    // Flush buffer.
+    if (sync() == -1) {
+        // Signal error when sync fails
+        return EOF;
+    }
+
+    // Set pointer to buffer.
+    setp(buffer, buffer + buffer_size);
+    return sputc(c);
+}
+
+// Flushes the buffer using the Zlib library for compression.
+int Compression::DeflateStreambuf::sync() {
+    if (pptr() > pbase()) {  // buffer not empty
+        int ret = write_buffer(Z_NO_FLUSH);
+        if (ret != Z_OK) {
+            return -1;
+        }
+        // Set pointer to buffer.
+        setp(buffer, buffer + buffer_size);
+    }
+    return 0;
+}
+
+// Write the current buffer using the Zlib library. While this flushes our
+// intermediate buffer, the Zlib library may not write all of the compressed
+// data to the file immediately.
+// When writing the buffer in between compression, the argument flush should
+// be equal to Z_NO_FINISH. After writing the final block of data, the
+// argument flush should be equal to Z_FINISH so Zlib knows to flush all of
+// the compressed data.
+int Compression::DeflateStreambuf::write_buffer(int flush) {
+    // Set buffer and buffer size.
+    strm.avail_in = pptr() - pbase();
+    strm.next_in = reinterpret_cast<unsigned char *>(pbase());
+
+    int ret;
+    // Create and set intermediate buffer for compressed data.
+    unsigned char *out = new unsigned char[buffer_size];
+    // Deflate and write compressed data to file until we do not fill the
+    // output buffer.
+    do {
+        strm.avail_out = buffer_size;
+        strm.next_out = out;
+
+        // Deflate buffer.
+        ret = deflate(&strm, flush);
+
+        // Write compressed data to file.
+        size_t have = buffer_size - strm.avail_out;
+
+        if (fwrite(out, 1, have, out_file) != have || ferror(out_file)) {
+            return Z_ERRNO;
+        }
+    } while (strm.avail_out == 0);
+
+    delete[] out;
+    return ret;
+}
+
+// Open streambuf and check for success.
+void Compression::DeflateStream::open(std::string const &filename) {
+    int state = DeflateStreambuf::open(filename);
+    if (state == ERROR) {
+        setstate(std::ios::badbit);
+    }
+}
+
+// Initialize buffer.
+Compression::InflateStreambuf::InflateStreambuf(size_t _buffer_size)
+    : buffer_size(_buffer_size) {
+    // Allocate new buffer.
+    buffer = new char[buffer_size];
+    // Set streambuf's internal pointer to buffer.
+    setg(buffer, buffer + buffer_size, buffer + buffer_size);
+}
+
+// Destructor deleted the allocated memory, closes the input file, and frees the
+// allocated Zlib state.
+Compression::InflateStreambuf::~InflateStreambuf() {
+    delete[] buffer;
+    if (in_file) {
+        fclose(in_file);
+    }
+    (void)inflateEnd(&strm);
+}
+
+// Open file and initialize Zlib state.
+int Compression::InflateStreambuf::open(std::string const &filename) {
+    // Open file.
+    in_file = fopen(filename.c_str(), "rb");
+    if (in_file == NULL) {
+        return ERROR;
+    }
+
+    // Initialize zlib stream.
+    strm.zalloc = Z_NULL;
+    strm.zfree = Z_NULL;
+    strm.opaque = Z_NULL;
+    int ret = inflateInit(&strm);
+    if (ret != Z_OK) {
+        return ERROR;
+    }
+    return OK;
+}
+
+// Read a character when the buffer is empty.
+int Compression::InflateStreambuf::underflow() {
+    if (gptr() < egptr()) {
+        return *gptr();
+    }
+
+    size_t nread = read_buffer();
+
+    if (nread <= 0) {
+        return EOF;
+    }
+    setg(buffer, buffer, buffer + nread);
+    return static_cast<unsigned char>(*gptr());
+}
+
+// Fill the buffer using the Zlib library for decompression, returns the number
+// of bytes that were read to the buffer.
+int Compression::InflateStreambuf::read_buffer() {
+    // Buffer to store data read from file.
+    unsigned char *in = new unsigned char[buffer_size];
+    strm.avail_in = fread(in, 1, buffer_size, in_file);
+    if (ferror(in_file)) {
+        (void)inflateEnd(&strm);
+        return 0;
+    }
+
+    // Return on EOF.
+    if (strm.avail_in == 0) {
+        return 0;
+    }
+    strm.next_in = in;
+
+    size_t bytes_read = 0;
+    // Read and inflate data until the output buffer is full or the input buffer
+    // is empty.
+    do {
+        // Set output buffer.
+        size_t size = buffer_size - bytes_read;
+        strm.avail_out = size;
+        strm.next_out = reinterpret_cast<unsigned char *>(eback() + bytes_read);
+
+        // Inflate data.
+        int ret = inflate(&strm, Z_NO_FLUSH);
+        switch (ret) {
+            case Z_NEED_DICT:
+                ret = Z_DATA_ERROR;
+                [[fallthrough]];
+            case Z_DATA_ERROR:
+            case Z_MEM_ERROR:
+                (void)inflateEnd(&strm);
+                return ret;
+        }
+        bytes_read += size - strm.avail_out;
+    } while (strm.avail_in != 0 && strm.avail_out != 0);
+
+    // Move to position in file directly after the last byte that was
+    // decompressed already.
+    fseek(in_file, -(int)strm.avail_in, SEEK_CUR);
+
+    delete[] in;
+    return bytes_read;
+}
+
+// Open streambuf and check for success.
+void Compression::InflateStream::open(std::string const &filename) {
+    int state = InflateStreambuf::open(filename);
+    if (state == ERROR) {
+        setstate(std::ios::badbit);
+    }
 }

--- a/src/lib/utils/compression.hpp
+++ b/src/lib/utils/compression.hpp
@@ -1,14 +1,104 @@
 #ifndef UTILS_COMPRESSION_HPP
 #define UTILS_COMPRESSION_HPP
 
+#include <zlib.h>
+#include <iostream>
+#include <streambuf>
 #include <vector>
 
 // This namespace contains necessary functions to (de)compress raw data.
 namespace Compression {
 
-// (De)compression.
+enum state { OK, ERROR };
+
+// Decompress raw data.
 int inflate(std::vector<uint8_t> &in_data, std::vector<uint8_t> &out_data,
             size_t decompressed_len);
+
+// Streambuf class allows a stream to write compressed data to a file by use of
+// an intermediate buffer.
+class DeflateStreambuf : public std::streambuf {
+    // Buffer to store information before compression.
+    char *buffer;
+    size_t buffer_size;
+
+    // File to write compressed data to.
+    FILE *out_file = nullptr;
+
+    // Zlib stream used in compression.
+    z_stream strm;
+
+   public:
+    // Constructor sets buffer size.
+    DeflateStreambuf(size_t _buffer_size = 16384);
+    // Destructor flushes the buffer, closes the file, and deletes buffer.
+    virtual ~DeflateStreambuf();
+
+    // Open file and allocate Zlib state.
+    int open(std::string const &filename);
+
+   private:
+    virtual int overflow(int c);  // Writes byte when buffer is full.
+    virtual int sync();           // Flushes the buffer.
+    int write_buffer(int flush);  // Compress data form buffer to file.
+};
+
+// DeflateStream uses the DeflateStreambuf to compress the data and write to a
+// file.
+class DeflateStream : private DeflateStreambuf, public std::ostream {
+   public:
+    DeflateStream(size_t buffer_size = 16384)
+        : DeflateStreambuf(buffer_size), std::ostream(this) {}
+    DeflateStream(std::string const &filename, size_t buffer_size = 16384)
+        : DeflateStreambuf(buffer_size), std::ostream(this) {
+        open(filename);
+    }
+
+    // Open streambuf and check for success.
+    void open(std::string const &filename);
+};
+
+// Streambuf class allows a stream to read data from a file and decompress it
+// using an intermediate buffer
+class InflateStreambuf : public std::streambuf {
+    // Buffer to store decompressed data.
+    char *buffer;
+    size_t buffer_size;
+
+    // File to read compressed data from.
+    FILE *in_file = nullptr;
+
+    // Zlib stream used in decompression.
+    z_stream strm;
+
+   public:
+    // Constructor sets buffer size.
+    InflateStreambuf(size_t _buffer_size = 16384);
+    // Destructor flushes the buffer, closes the file, and deletes buffer.
+    virtual ~InflateStreambuf();
+
+    // Open file and allocate Zlib state.
+    int open(std::string const &filename);
+
+   private:
+    virtual int underflow();  // Read byte when buffer is empty.
+    int read_buffer();        // Decompress data from file into the buffer.
+};
+
+// InflateStream uses the InflateStreambuf to decompress the data read from a
+// file.
+class InflateStream : private InflateStreambuf, public std::istream {
+   public:
+    InflateStream(size_t buffer_size = 16384)
+        : InflateStreambuf(buffer_size), std::istream(this) {}
+    InflateStream(std::string const &filename, size_t buffer_size = 16384)
+        : InflateStreambuf(buffer_size), std::istream(this) {
+        open(filename);
+    }
+
+    // Open streambuf and check for success.
+    void open(std::string const &filename);
+};
 
 }  // namespace Compression
 

--- a/src/python-bindings/pastaq/bindings.cpp
+++ b/src/python-bindings/pastaq/bindings.cpp
@@ -23,6 +23,7 @@
 #include "raw_data/raw_data.hpp"
 #include "raw_data/raw_data_serialize.hpp"
 #include "raw_data/xml_reader.hpp"
+#include "utils/compression.hpp"
 #include "utils/search.hpp"
 #include "utils/serialization.hpp"
 #include "warp2d/warp2d.hpp"
@@ -335,8 +336,8 @@ SimilarityResults find_similarity(std::vector<Centroid::Peak> &peak_list_a,
 void write_raw_data(const RawData::RawData &raw_data,
                     std::string &output_file) {
     // Open file stream.
-    std::ofstream stream;
-    stream.open(output_file, std::ios_base::out | std::ios_base::binary);
+    Compression::DeflateStream stream;
+    stream.open(output_file);
     if (!stream) {
         std::ostringstream error_stream;
         error_stream << "error: couldn't open output file" << output_file;
@@ -354,8 +355,8 @@ void write_raw_data(const RawData::RawData &raw_data,
 
 RawData::RawData read_raw_data(std::string &input_file) {
     // Open file stream.
-    std::ifstream stream;
-    stream.open(input_file, std::ios_base::in | std::ios_base::binary);
+    Compression::InflateStream stream;
+    stream.open(input_file);
     if (!stream) {
         std::ostringstream error_stream;
         error_stream << "error: couldn't open input file" << input_file;
@@ -374,8 +375,8 @@ RawData::RawData read_raw_data(std::string &input_file) {
 
 void write_grid(const Grid::Grid &grid, std::string &output_file) {
     // Open file stream.
-    std::ofstream stream;
-    stream.open(output_file, std::ios_base::out | std::ios_base::binary);
+    Compression::DeflateStream stream;
+    stream.open(output_file);
     if (!stream) {
         std::ostringstream error_stream;
         error_stream << "error: couldn't open output file" << output_file;
@@ -392,8 +393,8 @@ void write_grid(const Grid::Grid &grid, std::string &output_file) {
 
 Grid::Grid read_grid(std::string &input_file) {
     // Open file stream.
-    std::ifstream stream;
-    stream.open(input_file, std::ios_base::in | std::ios_base::binary);
+    Compression::InflateStream stream;
+    stream.open(input_file);
     if (!stream) {
         std::ostringstream error_stream;
         error_stream << "error: couldn't open input file" << input_file;
@@ -412,8 +413,8 @@ Grid::Grid read_grid(std::string &input_file) {
 
 void write_time_map(const Warp2D::TimeMap &time_map, std::string &output_file) {
     // Open file stream.
-    std::ofstream stream;
-    stream.open(output_file, std::ios_base::out | std::ios_base::binary);
+    Compression::DeflateStream stream;
+    stream.open(output_file);
     if (!stream) {
         std::ostringstream error_stream;
         error_stream << "error: couldn't open output file" << output_file;
@@ -431,8 +432,8 @@ void write_time_map(const Warp2D::TimeMap &time_map, std::string &output_file) {
 
 Warp2D::TimeMap read_time_map(std::string &input_file) {
     // Open file stream.
-    std::ifstream stream;
-    stream.open(input_file, std::ios_base::in | std::ios_base::binary);
+    Compression::InflateStream stream;
+    stream.open(input_file);
     if (!stream) {
         std::ostringstream error_stream;
         error_stream << "error: couldn't open input file" << input_file;
@@ -452,8 +453,8 @@ Warp2D::TimeMap read_time_map(std::string &input_file) {
 void write_peaks(const std::vector<Centroid::Peak> &peaks,
                  std::string &output_file) {
     // Open file stream.
-    std::ofstream stream;
-    stream.open(output_file, std::ios_base::out | std::ios_base::binary);
+    Compression::DeflateStream stream;
+    stream.open(output_file);
     if (!stream) {
         std::ostringstream error_stream;
         error_stream << "error: couldn't open output file" << output_file;
@@ -470,8 +471,8 @@ void write_peaks(const std::vector<Centroid::Peak> &peaks,
 
 std::vector<Centroid::Peak> read_peaks(std::string &input_file) {
     // Open file stream.
-    std::ifstream stream;
-    stream.open(input_file, std::ios_base::in | std::ios_base::binary);
+    Compression::InflateStream stream;
+    stream.open(input_file);
     if (!stream) {
         std::ostringstream error_stream;
         error_stream << "error: couldn't open input file" << input_file;
@@ -491,8 +492,8 @@ std::vector<Centroid::Peak> read_peaks(std::string &input_file) {
 std::vector<ProteinInference::InferredProtein> read_inferred_proteins(
     std::string &input_file) {
     // Open file stream.
-    std::ifstream stream;
-    stream.open(input_file, std::ios_base::in | std::ios_base::binary);
+    Compression::InflateStream stream;
+    stream.open(input_file);
     if (!stream) {
         std::ostringstream error_stream;
         error_stream << "error: couldn't open input file" << input_file;
@@ -515,8 +516,8 @@ void write_inferred_proteins(
     const std::vector<ProteinInference::InferredProtein> &inferred_proteins,
     std::string &output_file) {
     // Open file stream.
-    std::ofstream stream;
-    stream.open(output_file, std::ios_base::out | std::ios_base::binary);
+    Compression::DeflateStream stream;
+    stream.open(output_file);
     if (!stream) {
         std::ostringstream error_stream;
         error_stream << "error: couldn't open output file" << output_file;
@@ -537,8 +538,8 @@ void write_feature_clusters(
     const std::vector<MetaMatch::FeatureCluster> &feature_clusters,
     std::string &output_file) {
     // Open file stream.
-    std::ofstream stream;
-    stream.open(output_file, std::ios_base::out | std::ios_base::binary);
+    Compression::DeflateStream stream;
+    stream.open(output_file);
     if (!stream) {
         std::ostringstream error_stream;
         error_stream << "error: couldn't open output file" << output_file;
@@ -558,8 +559,8 @@ void write_feature_clusters(
 std::vector<MetaMatch::FeatureCluster> read_feature_clusters(
     std::string &input_file) {
     // Open file stream.
-    std::ifstream stream;
-    stream.open(input_file, std::ios_base::in | std::ios_base::binary);
+    Compression::InflateStream stream;
+    stream.open(input_file);
     if (!stream) {
         std::ostringstream error_stream;
         error_stream << "error: couldn't open input file" << input_file;
@@ -582,16 +583,15 @@ void write_peak_clusters(
     const std::vector<MetaMatch::PeakCluster> &peak_clusters,
     std::string &output_file) {
     // Open file stream.
-    std::ofstream stream;
-    stream.open(output_file, std::ios_base::out | std::ios_base::binary);
+    Compression::DeflateStream stream;
+    stream.open(output_file);
     if (!stream) {
         std::ostringstream error_stream;
         error_stream << "error: couldn't open output file" << output_file;
         throw std::invalid_argument(error_stream.str());
     }
 
-    if (!MetaMatch::Serialize::write_peak_clusters(stream,
-                                                      peak_clusters)) {
+    if (!MetaMatch::Serialize::write_peak_clusters(stream, peak_clusters)) {
         std::ostringstream error_stream;
         error_stream
             << "error: couldn't write the peak_clusters into the output file"
@@ -603,8 +603,8 @@ void write_peak_clusters(
 std::vector<MetaMatch::PeakCluster> read_peak_clusters(
     std::string &input_file) {
     // Open file stream.
-    std::ifstream stream;
-    stream.open(input_file, std::ios_base::in | std::ios_base::binary);
+    Compression::InflateStream stream;
+    stream.open(input_file);
     if (!stream) {
         std::ostringstream error_stream;
         error_stream << "error: couldn't open input file" << input_file;
@@ -612,8 +612,7 @@ std::vector<MetaMatch::PeakCluster> read_peak_clusters(
     }
 
     std::vector<MetaMatch::PeakCluster> peak_clusters;
-    if (!MetaMatch::Serialize::read_peak_clusters(stream,
-                                                     &peak_clusters)) {
+    if (!MetaMatch::Serialize::read_peak_clusters(stream, &peak_clusters)) {
         std::ostringstream error_stream;
         error_stream
             << "error: couldn't write the peak_clusters into the input file"
@@ -626,8 +625,8 @@ std::vector<MetaMatch::PeakCluster> read_peak_clusters(
 void write_features(const std::vector<FeatureDetection::Feature> &features,
                     std::string &output_file) {
     // Open file stream.
-    std::ofstream stream;
-    stream.open(output_file, std::ios_base::out | std::ios_base::binary);
+    Compression::DeflateStream stream;
+    stream.open(output_file);
     if (!stream) {
         std::ostringstream error_stream;
         error_stream << "error: couldn't open output file" << output_file;
@@ -645,8 +644,8 @@ void write_features(const std::vector<FeatureDetection::Feature> &features,
 
 std::vector<FeatureDetection::Feature> read_features(std::string &input_file) {
     // Open file stream.
-    std::ifstream stream;
-    stream.open(input_file, std::ios_base::in | std::ios_base::binary);
+    Compression::InflateStream stream;
+    stream.open(input_file);
     if (!stream) {
         std::ostringstream error_stream;
         error_stream << "error: couldn't open input file" << input_file;
@@ -666,8 +665,8 @@ std::vector<FeatureDetection::Feature> read_features(std::string &input_file) {
 void write_ident_data(const IdentData::IdentData &ident_data,
                       std::string &output_file) {
     // Open file stream.
-    std::ofstream stream;
-    stream.open(output_file, std::ios_base::out | std::ios_base::binary);
+    Compression::DeflateStream stream;
+    stream.open(output_file);
     if (!stream) {
         std::ostringstream error_stream;
         error_stream << "error: couldn't open output file" << output_file;
@@ -685,8 +684,8 @@ void write_ident_data(const IdentData::IdentData &ident_data,
 
 IdentData::IdentData read_ident_data(std::string &input_file) {
     // Open file stream.
-    std::ifstream stream;
-    stream.open(input_file, std::ios_base::in | std::ios_base::binary);
+    Compression::InflateStream stream;
+    stream.open(input_file);
     if (!stream) {
         std::ostringstream error_stream;
         error_stream << "error: couldn't open input file" << input_file;
@@ -707,8 +706,8 @@ IdentData::IdentData read_ident_data(std::string &input_file) {
 void write_linked_msms(const std::vector<Link::LinkedMsms> &linked_msms,
                        std::string &output_file) {
     // Open file stream.
-    std::ofstream stream;
-    stream.open(output_file, std::ios_base::out | std::ios_base::binary);
+    Compression::DeflateStream stream;
+    stream.open(output_file);
     if (!stream) {
         std::ostringstream error_stream;
         error_stream << "error: couldn't open output file" << output_file;
@@ -726,8 +725,8 @@ void write_linked_msms(const std::vector<Link::LinkedMsms> &linked_msms,
 
 std::vector<Link::LinkedMsms> read_linked_msms(std::string &input_file) {
     // Open file stream.
-    std::ifstream stream;
-    stream.open(input_file, std::ios_base::in | std::ios_base::binary);
+    Compression::InflateStream stream;
+    stream.open(input_file);
     if (!stream) {
         std::ostringstream error_stream;
         error_stream << "error: couldn't open input file" << input_file;
@@ -746,10 +745,10 @@ std::vector<Link::LinkedMsms> read_linked_msms(std::string &input_file) {
 }
 
 void write_linked_psm(const std::vector<Link::LinkedPsm> &linked_psm,
-                       std::string &output_file) {
+                      std::string &output_file) {
     // Open file stream.
-    std::ofstream stream;
-    stream.open(output_file, std::ios_base::out | std::ios_base::binary);
+    Compression::DeflateStream stream;
+    stream.open(output_file);
     if (!stream) {
         std::ostringstream error_stream;
         error_stream << "error: couldn't open output file" << output_file;
@@ -767,8 +766,8 @@ void write_linked_psm(const std::vector<Link::LinkedPsm> &linked_psm,
 
 std::vector<Link::LinkedPsm> read_linked_psm(std::string &input_file) {
     // Open file stream.
-    std::ifstream stream;
-    stream.open(input_file, std::ios_base::in | std::ios_base::binary);
+    Compression::InflateStream stream;
+    stream.open(input_file);
     if (!stream) {
         std::ostringstream error_stream;
         error_stream << "error: couldn't open input file" << input_file;


### PR DESCRIPTION
Add Inflate- and Deflate-streams that allow for the compression and decompression of temporary binary files.