### PR TITLE
build zlib on linux and windows; updated docs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,7 @@ target_include_directories(pastaqlib PUBLIC src/lib)
 if (WIN32)
     target_link_libraries(pastaqlib ${CMAKE_THREAD_LIBS_INIT} Eigen3::Eigen zlibstatic)
 else()
-    target_link_libraries(pastaqlib ${CMAKE_THREAD_LIBS_INIT} Eigen3::Eigen ZLIB::ZLIB)
+    target_link_libraries(pastaqlib ${CMAKE_THREAD_LIBS_INIT} Eigen3::Eigen zlib)
 endif()
 
 # Build the python bindings.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,12 +16,7 @@ if (MSVC)
     set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} /W4")
 endif()
 
-# find_package(Threads REQUIRED)
-if (WIN32)
-    add_subdirectory("ext/zlib")
-else()
-    find_package(zlib REQUIRED)
-endif()
+add_subdirectory("ext/zlib")
 add_subdirectory("ext/eigen")
 
 # Build pastaq library.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Installation
 
 To install from source, you will need to install a suitable C++ compiler and
-corresponding build tools for your platform as well as CMake and zlib. 
+corresponding build tools for your platform as well as CMake. 
 The instructions listed here refer to the installation of PASTAQ's Python
-bindings.  Currently the only external dependencies are included as git submodules.  
+bindings.  Currently the only external dependencies, including zlib, are included as git submodules.  
 
 To get started, clone this repository and initialize git submodules:
 


### PR DESCRIPTION
Small change to CML so zlib builds on both windows and linux.  Also updated docs.