### PR TITLE
Fix the shifted smoothing

### DIFF
--- a/src/lib/grid/grid.cpp
+++ b/src/lib/grid/grid.cpp
@@ -180,8 +180,8 @@ Grid::Grid Grid::_resample(const RawData::RawData &raw_data,
                         double b = (y - current_rt) / sigma_rt;
                         double weight = std::exp(-0.5 * (a * a + b * b));
 
-                        grid.data[i + j * n] += weight * current_intensity;
-                        weights[i + j * n] += weight;
+                        grid.data[index_mz + index_rt * n] += weight * current_intensity;
+                        weights[index_mz + index_rt * n] += weight;
                     }
                 }
             }


### PR DESCRIPTION
The smoothing is centered now using the appropriate current `mz` and `rt` indices

```
// Find the bin for the current retention time.
size_t index_rt = y_index(grid, current_rt);

// Find the bin for the current mz.
size_t index_mz = x_index(grid, current_mz);
```